### PR TITLE
Atualização e correção do Footer

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { HeaderComponent } from './layout/header/header.component';
 import { FooterComponent } from './layout/footer/footer.component';
+import { NewFooterComponent } from './layout/new-footer/new-footer.component';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { EvaluationModule } from './evaluation/evaluation.module';
 import { EvaluationPageComponent } from './pages/evaluation-page/evaluation-page.component';
@@ -43,6 +44,7 @@ export function HttpLoaderFactory(http: HttpClient) {
         AppComponent,
         HeaderComponent,
         FooterComponent,
+        NewFooterComponent,
         HomePageComponent,
         EvaluationPageComponent,
         BreadcrumbsComponent,

--- a/src/app/layout/new-footer/new-footer.component.html
+++ b/src/app/layout/new-footer/new-footer.component.html
@@ -1,0 +1,89 @@
+<footer class="app-footer">
+  <div class="footer-container">
+
+    <div class="footer">
+      <a routerLink="about" title="About page"> {{ 'HOMEPAGE.about' | translate }} </a>
+    </div>
+    <!-- Logos Section -->
+    <nav class="footer-logos" aria-label="Parceiros e financiadores">
+      <a
+        href="https://lasige.pt/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="footer-logo-link"
+        aria-label="Visitar site do LASIGE (abre em nova aba)">
+        <img
+          alt="Logo LASIGE"
+          src="assets/images/lasige_logo.png"
+          class="footer-logo">
+      </a>
+
+      <a
+        href="https://ciencias.ulisboa.pt/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="footer-logo-link"
+        aria-label="Visitar site da Faculdade de Ciências da Universidade de Lisboa (abre em nova aba)">
+        <img
+          alt="Logo FCUL"
+          src="assets/images/ciencias_ulisboa_marca_horizontal_rgb_branco.png"
+          class="footer-logo">
+      </a>
+
+      <a
+        href="https://www.fct.pt/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="footer-logo-link"
+        aria-label="Visitar site da Fundação para a Ciência e Tecnologia (abre em nova aba)">
+        <img
+          alt="Logo FCT"
+          src="assets/images/fct_logo.png"
+          class="footer-logo">
+      </a>
+
+      <a
+        href="https://www.w3.org/WAI/about/projects/wai-tools/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="footer-logo-link footer-logo-link--w3c"
+        aria-label="Visitar site do projeto W3C WAI-Tools (abre em nova aba)">
+        <svg
+          role="img"
+          viewBox="0 0 68 34"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="white"
+          class="footer-logo footer-logo--svg"
+          aria-label="Logo W3C">
+          <title>W3C WAI-Tools</title>
+          <g>
+            <path d="m16.117 1.006 5.759 19.58 5.759-19.58h4.17 11.444v1.946l-5.879 10.128c2.065.663 3.627 1.868 4.686 3.615 1.059 1.748 1.589 3.799 1.589 6.155 0 2.914-.775 5.363-2.324 7.348s-3.555 2.978-6.017 2.978c-1.854 0-3.469-.589-4.845-1.767-1.377-1.178-2.396-2.773-3.058-4.786l3.256-1.35c.477 1.218 1.106 2.178 1.887 2.879.781.702 1.701 1.052 2.76 1.052 1.112 0 2.052-.622 2.82-1.866.768-1.245 1.152-2.74 1.152-4.489 0-1.933-.411-3.429-1.231-4.488-.954-1.244-2.45-1.867-4.489-1.867h-1.588v-1.906l5.56-9.612h-6.712l-.382.65-8.163 27.548h-.397l-5.958-19.937-5.957 19.937h-.397l-9.53-32.168h4.17l5.759 19.58 3.892-13.185-1.906-6.395z"></path>
+            <path d="m64.92 1.006c-.819 0-1.554.295-2.111.861-.591.6-.92 1.376-.92 2.178s.313 1.545.887 2.128c.583.591 1.334.912 2.145.912.793 0 1.562-.321 2.161-.903.574-.557.887-1.3.887-2.136 0-.811-.321-1.57-.878-2.136-.584-.592-1.344-.904-2.171-.904zm2.643 3.065c0 .701-.271 1.351-.768 1.832-.524.507-1.174.777-1.892.777-.675 0-1.342-.278-1.84-.785s-.777-1.157-.777-1.849.287-1.368.802-1.891c.481-.49 1.131-.751 1.84-.751.726 0 1.376.271 1.883.785.49.489.752 1.147.752 1.882zm-2.559-1.807h-1.3v3.445h.65v-1.469h.642l.701 1.469h.726l-.769-1.57c.498-.102.785-.439.785-.929 0-.625-.472-.946-1.435-.946zm-.118.422c.608 0 .886.169.886.591 0 .405-.278.549-.87.549h-.549v-1.14z"></path>
+            <path d="m59.807.825.676 4.107-2.391 4.575s-.918-1.941-2.443-3.015c-1.285-.905-2.122-1.102-3.431-.832-1.681.347-3.587 2.357-4.419 4.835-.995 2.965-1.005 4.4-1.04 5.718-.056 2.113.277 3.362.277 3.362s-1.452-2.686-1.438-6.62c.009-2.808.451-5.354 1.75-7.867 1.143-2.209 2.842-3.535 4.35-3.691 1.559-.161 2.791.59 3.743 1.403 1 .854 2.01 2.721 2.01 2.721z"></path>
+            <path d="m60.102 24.063s-1.057 1.889-1.715 2.617c-.659.728-1.837 2.01-3.292 2.651s-2.218.762-3.656.624c-1.437-.138-2.772-.97-3.24-1.317s-1.664-1.369-2.34-2.322-1.733-2.859-1.733-2.859.589 1.91.958 2.721c.212.467.864 1.894 1.789 3.136.863 1.159 2.539 3.154 5.086 3.604 2.547.451 4.297-.693 4.73-.97s1.346-1.042 1.924-1.66c.603-.645 1.174-1.468 1.49-1.962.231-.36.607-1.092.607-1.092z"></path>
+          </g>
+        </svg>
+      </a>
+    </nav>
+
+    <!-- Information Section -->
+    <div class="footer-info">
+      <div class="footer-info__text">
+        <p class="footer-info__institution">
+          <span class="footer-info__full">LASIGE - Departamento de Informática</span>
+          <span class="footer-info__short">LASIGE - DI</span>
+        </p>
+        <p class="footer-info__university">
+          <span class="footer-info__full">Faculdade de Ciências da Universidade de Lisboa</span>
+          <span class="footer-info__short">FCUL</span>
+        </p>
+      </div>
+
+      <!-- Contact Section -->
+      <div class="footer-info__contact">
+        <div class="footer-info__title">E-mail:</div>
+        <div class="footer-info__contact-email">qualweb@fc.ul.pt</div>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/src/app/layout/new-footer/new-footer.component.scss
+++ b/src/app/layout/new-footer/new-footer.component.scss
@@ -1,0 +1,206 @@
+// Variables
+$footer-bg-color: #943709;
+$footer-text-color: #ffffff;
+$footer-padding-desktop: 1.5rem 2rem;
+$footer-padding-mobile: 1.25rem 1rem;
+$logo-gap-desktop: 2rem;
+$logo-gap-mobile: 1.25rem;
+$logo-max-height: 60px;
+$transition-duration: 0.3s;
+
+// Breakpoints
+$breakpoint-md: 960px;
+$breakpoint-sm: 600px;
+
+.app-footer {
+  background-color: $footer-bg-color;
+  width: 100%;
+  color: $footer-text-color;
+  margin-top: 48px;
+}
+
+.footer {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+
+  a {
+    color: white;
+    text-transform: uppercase;
+    font-family: 'Oswald', sans-serif;
+    text-decoration: none;
+    text-align: center;
+    width: 100%;
+    transition: transform $transition-duration ease, opacity $transition-duration ease;
+
+
+      &:hover,
+      &:focus {
+        transform: translateY(-2px);
+        opacity: 0.85;
+        outline-offset: 4px;
+        border-radius: 4px;
+      }
+  }
+}
+
+.footer-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: $footer-padding-desktop;
+
+  @media (max-width: $breakpoint-sm) {
+    gap: 1.25rem;
+  }
+
+  @media (max-width: $breakpoint-md) {
+    padding: $footer-padding-mobile;
+  }
+}
+
+.footer-logos {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: $logo-gap-desktop;
+  padding: 0.5rem 0;
+
+  @media (max-width: $breakpoint-md) {
+    gap: $logo-gap-mobile;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    gap: 1rem;
+  }
+}
+
+.footer-logo-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: $logo-max-height;
+  transition: transform $transition-duration ease, opacity $transition-duration ease;
+
+  &:hover,
+  &:focus {
+    transform: translateY(-2px);
+    opacity: 0.85;
+    outline-offset: 4px;
+    border-radius: 4px;
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    height: 50px;
+  }
+}
+
+.footer-logo {
+  max-height: 100%;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+
+  &--svg {
+    height: 100%;
+    width: auto;
+    min-width: 80px;
+
+    @media (max-width: $breakpoint-sm) {
+      min-width: 70px;
+    }
+  }
+}
+
+
+.footer-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+
+  @media (max-width: $breakpoint-md) {
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  &__text {
+    flex: 1;
+
+    p {
+      margin: 0;
+      line-height: 1.6;
+      font-size: 0.9rem;
+
+      @media (max-width: $breakpoint-sm) {
+        font-size: 0.85rem;
+      }
+    }
+  }
+
+  &__institution,
+  &__university {
+    margin-bottom: 0.25rem;
+  }
+
+  &__full {
+    display: inline;
+
+    @media (max-width: $breakpoint-md) {
+      display: none;
+    }
+  }
+
+  &__short {
+    display: none;
+
+    @media (max-width: $breakpoint-md) {
+      display: inline;
+    }
+  }
+
+  &__contact-site {
+    color: whitesmoke;
+  }
+}
+
+.footer-logo-link:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 6px;
+  border-radius: 4px;
+}
+
+.footer-info__text p {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+
+@media print {
+  .app-footer {
+    background-color: transparent;
+    color: #000000;
+    border-top: 2px solid #000000;
+    padding: 1rem;
+
+    .footer-logo-link {
+      &:hover,
+      &:focus {
+        transform: none;
+        opacity: 1;
+      }
+    }
+
+    .footer-info__language {
+      display: none;
+    }
+  }
+}

--- a/src/app/layout/new-footer/new-footer.component.spec.ts
+++ b/src/app/layout/new-footer/new-footer.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewFooterComponent } from './new-footer.component';
+
+describe('FooterComponent', () => {
+  let component: NewFooterComponent;
+  let fixture: ComponentFixture<NewFooterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NewFooterComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewFooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/layout/new-footer/new-footer.component.ts
+++ b/src/app/layout/new-footer/new-footer.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'new-footer',
+  templateUrl: './new-footer.component.html',
+  styleUrls: ['./new-footer.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NewFooterComponent implements OnInit {
+
+  // selectedLang: string;
+
+  constructor(public translate: TranslateService) { }
+
+  ngOnInit(): void {
+    // this.selectedLang = this.translate.currentLang;
+  }
+
+ /*
+  changeLanguage(): void {
+    this.translate.use(this.selectedLang);
+    localStorage.setItem('language', this.selectedLang);
+  }
+  */
+}

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -62,4 +62,4 @@
   </div>
 </div>
 
-<app-footer></app-footer>
+<new-footer></new-footer>

--- a/src/app/pages/about-page/about-page.component.scss
+++ b/src/app/pages/about-page/about-page.component.scss
@@ -49,11 +49,6 @@ p:last-of-type {
   padding-bottom: 4em;
 }
 
-app-footer {
-  background-color: #943709;
-  position: fixed;
-  bottom: 0;
-}
 
 .combo_breaker {
   margin: 2.5em 0 0.2em;

--- a/src/app/pages/home-page/home-page.component.html
+++ b/src/app/pages/home-page/home-page.component.html
@@ -2,11 +2,10 @@
   <img src="assets/images/logo2.png" alt="Qualweb logo"/>
 </div>
 <section fxLayout="row" fxLayoutAlign="center center">
-  <div fxFlex="60" fxFlex.lt-md="80">
+  <div class="home-content" fxFlex="60" fxFlex.lt-md="80">
     <h1>{{ 'HOMEPAGE.title' | translate }}</h1>
     <app-url-input></app-url-input>
   </div>
 </section>
-<div fxLayout="row" class="footer">
-  <a routerLink="about" title="About page"> {{ 'HOMEPAGE.about' | translate }} </a>
-</div>
+
+<new-footer></new-footer>

--- a/src/app/pages/home-page/home-page.component.scss
+++ b/src/app/pages/home-page/home-page.component.scss
@@ -1,24 +1,10 @@
+.home-content {
+  min-height: 50vh;
+}
+
 img {
   width: 25vw;
   min-width: 250px;
   margin-top: 3%;
 }
 
-.footer {
-  width: 100%;
-  height: 50px;
-  text-align: center;
-  font-size: 1.1em;
-  padding: 1vh 0;
-  background-color: #943709;
-  place-content: center;
-  position: fixed;
-  bottom: 0;
-  a {
-    color: white;
-    text-transform: uppercase;
-    font-family: 'Oswald', sans-serif;
-    text-decoration: none;
-    width: 100%;
-  }
-}


### PR DESCRIPTION
### Antes das alterações, o footer do website apresentava alguns problemas estruturais e de consistência entre páginas. Abaixo segue um resumo dos pontos identificados:

#### 1. Footer ocultava o input com zoom aplicado:
Ao aumentar o zoom, o footer sobrepunha o campo de input.

<img width="1286" height="974" alt="image" src="https://github.com/user-attachments/assets/eed9eda3-fbc2-4c69-b75e-127505814dc9" />

#### 2. Falta de consistência entre /home e /about:

Os footers dessas páginas diferiam em estrutura, elementos e tamanho, gerando inconsistência visual e duplicação de código.

<img width="1286" height="214" alt="image" src="https://github.com/user-attachments/assets/2e6531d1-d9af-41e5-be61-9ed67b55ea4d" />
<img width="1286" height="214" alt="image" src="https://github.com/user-attachments/assets/cabb6a86-b56f-4ec5-9c44-c968d4d49901" />

#### 3. Footer de /about quebrado:

No /about, o footer não utilizava a largura completa e os links/logos tinham baixa legibilidade e reduzida área de interação.

<img width="900" height="214" alt="image" src="https://github.com/user-attachments/assets/c33e8913-7bc7-41a3-8567-e5b549c801f0" />

#### 4. Link quebrado

O link para o site da LASIGE utilizava um endpoint inativo. Foi atualizado para uma URL funcional.
- Anterior: http://www.lasige.di.fc.ul.pt (inativo)
- Atual: https://lasige.pt/ (ativo)

### Solução aplicada
- Unificação dos footers em um único componente para todas as páginas.
- Correção de layout para evitar sobreposição com zoom.
- Ajuste de largura e espaçamento para melhorar legibilidade.
- Atualização de link inválido para URL funcional.

Componente final (unificado e responsivo):
<img width="1594" height="255" alt="image" src="https://github.com/user-attachments/assets/2dfdf310-8401-4483-a0f8-c030be3810d1" />
<img width="365" height="255" alt="image" src="https://github.com/user-attachments/assets/4678a09a-4990-45c1-8ede-ccfb61964676" />


### Teste

As alterações foram testadas em:
- Zoom 100% → 200%
- Resoluções desktop e mobile
- Páginas /home, /about e fluxos relacionados
 - Chrome/Firefox (Desktop)
 - DevTools
