### PR TITLE
ci: update GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build & Test (Node.js v12.x)
-      uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
         cache: 'npm'


### PR DESCRIPTION
## Summary

Updates outdated GitHub Actions to fix CI cache errors.

## Changes

- `actions/checkout`: v2 → v4
- `actions/setup-node`: v2 → v4  
- Fixed misleading step name (said "Node.js v12.x" but uses v16.x)

## Why

The CI was failing with `Error: Cache service responded with 400` due to known issues with the npm caching in older `setup-node` versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)