### PR TITLE
fix: trim URL input to prevent evaluation failures

### DIFF
--- a/src/app/evaluation/url-input/url-input.component.ts
+++ b/src/app/evaluation/url-input/url-input.component.ts
@@ -43,7 +43,7 @@ export class UrlInputComponent implements OnInit {
     url = url.replace('http://', '');
     url = url.replace('www.', '');*/
 
-    this.router.navigate(['/', encodeURIComponent(this.urlForm.value)], {
+    this.router.navigate(['/', encodeURIComponent(this.urlForm.value.trim())], {
       queryParams: {
         'type-act': this.executeACT ? 'checked' : 'unchecked',
         'type-wcag': this.executeWCAG ? 'checked' : 'unchecked',
@@ -52,7 +52,7 @@ export class UrlInputComponent implements OnInit {
   }
 
   urlValidator(control: AbstractControl): any {
-    const url = control.value;
+    const url = control.value?.trim();
 
     if (url === '' || url === null) {
       return null;


### PR DESCRIPTION
## Summary
- Adds `trim()` to the URL input value in the submit handler to remove leading/trailing whitespace
- Adds `trim()` to the URL validator so validation works correctly with padded URLs
- Fixes the issue where accidentally adding a space to a URL would cause evaluation to fail

## Test plan
- [ ] Enter a URL with a leading space (e.g., ` https://example.com`) and verify evaluation works
- [ ] Enter a URL with a trailing space (e.g., `https://example.com `) and verify evaluation works
- [ ] Enter a URL without any spaces and verify it still works as expected

Closes #34